### PR TITLE
Update to actions/download-artifact@v3

### DIFF
--- a/.github/workflows/reqnroll.actions.android.yaml
+++ b/.github/workflows/reqnroll.actions.android.yaml
@@ -68,9 +68,10 @@ jobs:
       # Authenticates packages to push to nuget.org.
       # It's only the way to push a package to nuget.org feed for macOS/Linux machines due to API key config store limitations.
       - name: Download a single artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: NuGet-Package
+          path: NuGet-Package
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'

--- a/.github/workflows/reqnroll.actions.appium.yaml
+++ b/.github/workflows/reqnroll.actions.appium.yaml
@@ -57,9 +57,10 @@ jobs:
       # Authenticates packages to push to nuget.org.
       # It's only the way to push a package to nuget.org feed for macOS/Linux machines due to API key config store limitations.
       - name: Download a single artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: NuGet-Package
+          path: NuGet-Package
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'

--- a/.github/workflows/reqnroll.actions.boaconstrictor.yaml
+++ b/.github/workflows/reqnroll.actions.boaconstrictor.yaml
@@ -61,9 +61,10 @@ jobs:
       # Authenticates packages to push to nuget.org.
       # It's only the way to push a package to nuget.org feed for macOS/Linux machines due to API key config store limitations.
       - name: Download a single artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: NuGet-Package
+          path: NuGet-Package
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'

--- a/.github/workflows/reqnroll.actions.browserstack.yaml
+++ b/.github/workflows/reqnroll.actions.browserstack.yaml
@@ -65,9 +65,10 @@ jobs:
       # Authenticates packages to push to nuget.org.
       # It's only the way to push a package to nuget.org feed for macOS/Linux machines due to API key config store limitations.
       - name: Download a single artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: NuGet-Package
+          path: NuGet-Package
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'

--- a/.github/workflows/reqnroll.actions.configuration.yaml
+++ b/.github/workflows/reqnroll.actions.configuration.yaml
@@ -57,9 +57,10 @@ jobs:
       # Authenticates packages to push to nuget.org.
       # It's only the way to push a package to nuget.org feed for macOS/Linux machines due to API key config store limitations.
       - name: Download a single artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: NuGet-Package
+          path: NuGet-Package
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'

--- a/.github/workflows/reqnroll.actions.docker.yaml
+++ b/.github/workflows/reqnroll.actions.docker.yaml
@@ -63,7 +63,7 @@ jobs:
       # Authenticates packages to push to nuget.org.
       # It's only the way to push a package to nuget.org feed for macOS/Linux machines due to API key config store limitations.
       - name: Download a single artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: NuGet-Package
       - uses: actions/setup-dotnet@v1

--- a/.github/workflows/reqnroll.actions.lambdatest.yaml
+++ b/.github/workflows/reqnroll.actions.lambdatest.yaml
@@ -69,7 +69,7 @@ jobs:
   #   if: github.ref == 'refs/heads/main'
   #   steps:
   #   - name: Download a single artifact
-  #     uses: actions/download-artifact@v2
+  #     uses: actions/download-artifact@v3
   #     with:
   #       name: test-results
   #   - uses: dorny/test-reporter@v1
@@ -90,9 +90,10 @@ jobs:
       # Authenticates packages to push to nuget.org.
       # It's only the way to push a package to nuget.org feed for macOS/Linux machines due to API key config store limitations.
       - name: Download a single artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: NuGet-Package
+          path: NuGet-Package
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'

--- a/.github/workflows/reqnroll.actions.playwright.yaml
+++ b/.github/workflows/reqnroll.actions.playwright.yaml
@@ -62,9 +62,10 @@ jobs:
       # Authenticates packages to push to nuget.org.
       # It's only the way to push a package to nuget.org feed for macOS/Linux machines due to API key config store limitations.
       - name: Download a single artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: NuGet-Package
+          path: NuGet-Package
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'

--- a/.github/workflows/reqnroll.actions.selenium.yaml
+++ b/.github/workflows/reqnroll.actions.selenium.yaml
@@ -62,9 +62,10 @@ jobs:
       # Authenticates packages to push to nuget.org.
       # It's only the way to push a package to nuget.org feed for macOS/Linux machines due to API key config store limitations.
       - name: Download a single artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: NuGet-Package
+          path: NuGet-Package
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'

--- a/.github/workflows/reqnroll.actions.windowsAppDriver.yaml
+++ b/.github/workflows/reqnroll.actions.windowsAppDriver.yaml
@@ -60,9 +60,10 @@ jobs:
       # Authenticates packages to push to nuget.org.
       # It's only the way to push a package to nuget.org feed for macOS/Linux machines due to API key config store limitations.
       - name: Download a single artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: NuGet-Package
+          path: NuGet-Package
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'


### PR DESCRIPTION

### 🤔 What's changed?
- Update to actions/download-artifact@v3
- Added the path for backwards comp, see See https://github.com/actions-marketplace-validations/actions_download-artifact
  ![image](https://github.com/user-attachments/assets/ae2f2fea-eeb8-4ba5-9c0e-4a01328e0b89)







### ⚡️ What's your motivation? 
The publish still fails

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->


- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)